### PR TITLE
fix map values handling of dot properties

### DIFF
--- a/lib/mapValues.js
+++ b/lib/mapValues.js
@@ -44,7 +44,7 @@ module.exports = async (collection = {}, task = () => {}, options) => {
             return reject(error);
         });
         limiter.on('iteration', ({ key, resultValue } = {}) => {
-            _.set(output, key, resultValue);
+            _.set(output, [key], resultValue);
         });
         limiter.on('done', () => {
             return resolve(output);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "await-the",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "A utility module which provides straight-forward, powerful functions for working with async/await in JavaScript.",
     "main": "index.js",
     "author": "Olono, Inc.",

--- a/test/mapValues.js
+++ b/test/mapValues.js
@@ -38,7 +38,7 @@ describe('Map Values test', function() {
 
     it('should run in parallel if the limit greater than 1', async () => {
         const collection = {
-            item1: 'item-1',
+            'item1.dummy': 'item-1',
             item2: 'item-2',
             item3: 'item-3'
         };
@@ -52,7 +52,7 @@ describe('Map Values test', function() {
         const duration = Date.now() - start;
         assert(duration < 1500, 'Expected promises to run in parallel');
         assert.deepStrictEqual(output, {
-            item1: 'item-1item1',
+            'item1.dummy': 'item-1item1.dummy',
             item2: 'item-2item2',
             item3: 'item-3item3'
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

when map values was iterating over a key that had dots in it it was setting the values back as nested properties

## How Has This Been Tested

updated unit tests to check this condition