### PR TITLE
Migrate p-any and p-all to native functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,15 @@ npm install await-the
 <dt><a href="#module_Limiter">Limiter</a></dt>
 <dd><p>Given a collection and a task return resolved values of the task being ran per value via the emitters</p>
 </dd>
+<dt><a href="#module_all">all</a> ⇒ <code>Array</code></dt>
+<dd><p>Given a collection of functions, promises, or basic types &#39;run&#39; them all at a specified limit</p>
+</dd>
 <dt><a href="#module_callback">callback</a></dt>
 <dd><p>Utility for making optional callbacks easier. If an error param exists, it will throw an error for promises
 or return the error to a callback.</p>
 </dd>
 <dt><a href="#module_each">each</a></dt>
-<dd><p>Given an array, run the given asynchronous task in parallel for each value of the array.</p>
+<dd><p>Given a collection, run the given asynchronous task in parallel for each value of the collection.</p>
 </dd>
 <dt><a href="#module_map">map</a> ⇒ <code>Array</code></dt>
 <dd><p>Given a collection run a map over it</p>
@@ -94,6 +97,31 @@ limiter.on('error', ({error}) => {
 // begin iteration
 limiter.start();
 ```
+<a name="module_all"></a>
+
+## all ⇒ <code>Array</code>
+Given a collection of functions, promises, or basic types 'run' them all at a specified limit
+
+**Returns**: <code>Array</code> - array of the resolved promises  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| collection | <code>Array</code> \| <code>Object</code> | Array or object of items to run the asynchronous task with. |
+| options | <code>Object</code> | Optional overrides. |
+| options.limit | <code>Number</code> | Optional limit to # of tasks to run in parallel. |
+
+**Example**  
+```js
+const the = require('await-the');
+await the.all(
+    [
+        new Promise(resolve => resolve('hello')),
+        'world',
+        () => 'how are you?'
+    ],
+    { limit: 2 }
+ );
+```
 <a name="module_callback"></a>
 
 ## callback
@@ -127,13 +155,13 @@ myFunc(args, (err, result) => {});
 <a name="module_each"></a>
 
 ## each
-Given an array, run the given asynchronous task in parallel for each value of the array.
+Given a collection, run the given asynchronous task in parallel for each value of the collection.
 
 
 | Param | Type | Description |
 | --- | --- | --- |
 | collection | <code>Array</code> \| <code>Object</code> | Array or object of items to run the asynchronous task with. |
-| task | <code>function</code> | The async function to be run on each value in the array. |
+| task | <code>function</code> | The async function to be run on each value in the collection. |
 | options | <code>Object</code> | Optional overrides. |
 | options.limit | <code>Number</code> | Optional limit to # of tasks to run in parallel. |
 
@@ -141,7 +169,7 @@ Given an array, run the given asynchronous task in parallel for each value of th
 ```js
 const the = require('await-the');
 await the.each([1,2,3], someAsyncFunction, { limit: 2 });
-// will call `someAsyncFunction` on each value of the array, with at most two functions
+// will call `someAsyncFunction` on each value of the collection, with at most two functions
 // running in parallel at a time.
 ```
 <a name="module_map"></a>

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Given a collection and a task return true if any promise resolves
 
 **Example**  
 ```js
-const the = require('await-the)
+const the = require('await-the')
 const collection = ['item1', 'item2', 'item3'];
 const task = async (value, index) => {
     if (index === 1) {

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ npm install await-the
 <dt><a href="#module_all">all</a> ⇒ <code>Array</code></dt>
 <dd><p>Given a collection of functions, promises, or basic types &#39;run&#39; them all at a specified limit</p>
 </dd>
+<dt><a href="#module_any">any</a> ⇒ <code>Boolean</code></dt>
+<dd><p>Given a collection and a task return true if any promise resolves</p>
+</dd>
 <dt><a href="#module_callback">callback</a></dt>
 <dd><p>Utility for making optional callbacks easier. If an error param exists, it will throw an error for promises
 or return the error to a callback.</p>
@@ -121,6 +124,32 @@ await the.all(
     ],
     { limit: 2 }
  );
+```
+<a name="module_any"></a>
+
+## any ⇒ <code>Boolean</code>
+Given a collection and a task return true if any promise resolves
+
+**Returns**: <code>Boolean</code> - true if a promise resolves otherwise throws an error  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| collection | <code>Array</code> \| <code>Object</code> | Array or object of items to run the asynchronous task over. |
+| task | <code>function</code> | The async function to be run on each value in the collection. |
+
+**Example**  
+```js
+const the = require('await-the)
+const collection = ['item1', 'item2', 'item3'];
+const task = async (value, index) => {
+    if (index === 1) {
+        return await new Promise(resolve => resolve());
+    } else {
+        throw new Error('test error');
+    }
+};
+const result = await the.any(collection, task);
+// result is true
 ```
 <a name="module_callback"></a>
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const all = require('p-all');
+const all = require('./lib/all');
 const any = require('p-any');
 const callback = require('./lib/callback');
 const doWhilst = require('p-do-whilst');

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const all = require('./lib/all');
-const any = require('p-any');
+const any = require('./lib/any');
 const callback = require('./lib/callback');
 const doWhilst = require('p-do-whilst');
 const each = require('./lib/each');
@@ -34,7 +34,7 @@ module.exports = {
     mapValues,
     result,
     retry,
-    start: any,
+    some: any,
     times,
     wait,
     waterfall,

--- a/lib/Limiter.js
+++ b/lib/Limiter.js
@@ -174,7 +174,7 @@ module.exports = class Limiter {
         }
 
         // alert the caller an iteration is complete
-        this.emit('iteration', { key, resultValue, index });
+        this.emit('iteration', { key, resultValue, error, index });
 
         // if we are done emit
         if (this.numberDone >= _.size(this.collection)) {

--- a/lib/Limiter.js
+++ b/lib/Limiter.js
@@ -71,6 +71,9 @@ module.exports = class Limiter {
      * @returns {undefined}
      */
     start() {
+        // indicate we are started
+        this.stopped = false;
+
         // don't do any work if an empty collection is supplied
         if (_.size(this.collection) === 0) {
             return this.emit('done');
@@ -80,6 +83,13 @@ module.exports = class Limiter {
         // since the limit defaults to infinity we take the min of the collection vs limit
         const initialSetSize = _.min([this.limit, _.size(this.collection)]);
         _.times(initialSetSize, () => this.iterate());
+    }
+
+    /**
+     * stop - stop iteration
+     */
+    stop() {
+        this.stopped = true;
     }
 
     /**
@@ -145,6 +155,11 @@ module.exports = class Limiter {
 
         // if there has already been an error stop emitting
         if (this.error && this.bailOnError) {
+            return;
+        }
+
+        // if limiter.stop() has been called stop iteration
+        if (this.stopped) {
             return;
         }
 

--- a/lib/all.js
+++ b/lib/all.js
@@ -1,0 +1,45 @@
+/**
+ * @file Given a collection of functions, promises, or basic types 'run' them all at a specified limit
+ * @copyright Copyright (c) 2018 Olono, Inc.
+ */
+
+'use strict';
+const _ = require('lodash');
+const map = require('./map');
+
+/**
+ * Given a collection of functions, promises, or basic types 'run' them all at a specified limit
+ *
+ * @module all
+ * @example
+ * const the = require('await-the');
+ * await the.all(
+ *     [
+ *         new Promise(resolve => resolve('hello')),
+ *         'world',
+ *         () => 'how are you?'
+ *     ],
+ *     { limit: 2 }
+ *  );
+ *
+ * @param {Array|Object} collection Array or object of items to run the asynchronous task with.
+ * @param {Object} options Optional overrides.
+ * @param {Number} options.limit Optional limit to # of tasks to run in parallel.
+ * @returns {Array} array of the resolved promises
+ */
+module.exports = async (collection, options) =>
+    await map(
+        collection,
+        async item => {
+            if (!item) {
+                return item;
+            }
+
+            if (_.isFunction(item)) {
+                return await item();
+            }
+
+            return item;
+        },
+        options
+    );

--- a/lib/any.js
+++ b/lib/any.js
@@ -1,0 +1,54 @@
+/**
+ * @file Given a collection and a task return true if any promise resolves
+ * @copyright Copyright (c) 2018 Olono, Inc.
+ */
+
+'use strict';
+
+const Limiter = require('./Limiter');
+
+/**
+ * Given a collection and a task return true if any promise resolves
+ * @module any
+ * @alias some
+ * @example
+ * const the = require('await-the)
+ * const collection = ['item1', 'item2', 'item3'];
+ * const task = async (value, index) => {
+ *     if (index === 1) {
+ *         return await new Promise(resolve => resolve());
+ *     } else {
+ *         throw new Error('test error');
+ *     }
+ * };
+ * const result = await the.any(collection, task);
+ * // result is true
+ * @param {Array|Object} collection Array or object of items to run the asynchronous task over.
+ * @param {Function} task The async function to be run on each value in the collection.
+ * @returns {Boolean} true if a promise resolves otherwise throws an error
+ */
+module.exports = async (collection, task) => {
+    return new Promise((resolve, reject) => {
+        const limiter = new Limiter(collection, task, { bailOnError: false });
+
+        // indicates if we have returned yet
+        let returned = false;
+        limiter.on('iteration', ({ error }) => {
+            if (error) {
+                return;
+            }
+
+            limiter.stop();
+            returned = true;
+            return resolve(true);
+        });
+
+        limiter.on('done', () => {
+            if (!returned) {
+                return reject(new Error('No promises resolved'));
+            }
+        });
+
+        limiter.start();
+    });
+};

--- a/lib/any.js
+++ b/lib/any.js
@@ -32,22 +32,16 @@ module.exports = async (collection, task) => {
         const limiter = new Limiter(collection, task, { bailOnError: false });
 
         // indicates if we have returned yet
-        let returned = false;
         limiter.on('iteration', ({ error }) => {
             if (error) {
                 return;
             }
 
             limiter.stop();
-            returned = true;
             return resolve(true);
         });
 
-        limiter.on('done', () => {
-            if (!returned) {
-                return reject(new Error('No promises resolved'));
-            }
-        });
+        limiter.on('done', () => reject(new Error('No promises resolved')));
 
         limiter.start();
     });

--- a/lib/any.js
+++ b/lib/any.js
@@ -12,7 +12,7 @@ const Limiter = require('./Limiter');
  * @module any
  * @alias some
  * @example
- * const the = require('await-the)
+ * const the = require('await-the')
  * const collection = ['item1', 'item2', 'item3'];
  * const task = async (value, index) => {
  *     if (index === 1) {

--- a/lib/each.js
+++ b/lib/each.js
@@ -7,17 +7,17 @@
 const map = require('./map');
 
 /**
- * Given an array, run the given asynchronous task in parallel for each value of the array.
+ * Given a collection, run the given asynchronous task in parallel for each value of the collection.
  *
  * @module each
  * @example
  * const the = require('await-the');
  * await the.each([1,2,3], someAsyncFunction, { limit: 2 });
- * // will call `someAsyncFunction` on each value of the array, with at most two functions
+ * // will call `someAsyncFunction` on each value of the collection, with at most two functions
  * // running in parallel at a time.
  *
  * @param {Array|Object} collection Array or object of items to run the asynchronous task with.
- * @param {Function} task The async function to be run on each value in the array.
+ * @param {Function} task The async function to be run on each value in the collection.
  * @param {Object} options Optional overrides.
  * @param {Number} options.limit Optional limit to # of tasks to run in parallel.
  */

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "license": "MIT",
     "dependencies": {
         "lodash": "^4.17.10",
-        "p-all": "^1.0.0",
         "p-any": "^1.1.0",
         "p-do-whilst": "^0.1.0",
         "p-every": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "license": "MIT",
     "dependencies": {
         "lodash": "^4.17.10",
-        "p-any": "^1.1.0",
         "p-do-whilst": "^0.1.0",
         "p-every": "^1.0.2",
         "p-times": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "await-the",
-    "version": "2.0.1",
+    "version": "3.0.0",
     "description": "A utility module which provides straight-forward, powerful functions for working with async/await in JavaScript.",
     "main": "index.js",
     "author": "Olono, Inc.",

--- a/test/Limiter.js
+++ b/test/Limiter.js
@@ -7,166 +7,196 @@ const assert = require('assert');
 describe('Limiter test', function() {
     this.timeout(30000);
 
-    it('should return if no collection is supplied', done => {
-        const limiter = new the.Limiter();
+    it('should return if no collection is supplied', async () => {
+        return new Promise((resolve, reject) => {
+            const limiter = new the.Limiter();
 
-        let iterations = 0;
-        limiter.on('iteration', () => {
-            iterations++;
-        });
+            let iterations = 0;
+            limiter.on('iteration', () => {
+                iterations++;
+            });
 
-        limiter.on('done', () => {
-            assert.strictEqual(iterations, 0);
-            return done();
-        });
-
-        limiter.on('error', ({ error }) => {
-            assert(!error, `Got error ${error.message}`);
-            return done();
-        });
-
-        limiter.start();
-    });
-
-    it('should do iterate 2 times and call done', done => {
-        const collection = ['item1', 'item2'];
-        const limiter = new the.Limiter(collection);
-
-        let iterations = 0;
-        limiter.on('iteration', () => {
-            iterations++;
-        });
-
-        limiter.on('done', () => {
-            assert.strictEqual(iterations, 2);
-            return done();
-        });
-
-        limiter.on('error', ({ error }) => {
-            assert(!error, `Got error ${error.message}`);
-            return done();
-        });
-
-        limiter.start();
-    });
-
-    it('should be able to run serially with a limit of 1', done => {
-        const collection = ['waiter', 'check please'];
-        const limiter = new the.Limiter(
-            collection,
-            async (value, key) => {
-                if (key === 0) {
-                    await the.wait(1000);
+            limiter.on('done', () => {
+                try {
+                    assert.strictEqual(iterations, 0);
+                } catch (e) {
+                    return reject(e);
                 }
+                return resolve();
+            });
 
-                return value;
-            },
-            { limit: 1 }
-        );
+            limiter.on('error', ({ error }) => {
+                return reject(`Got error ${error.message}`);
+            });
 
-        let results = [];
-        limiter.on('iteration', ({ resultValue }) => {
-            results.push(resultValue);
+            limiter.start();
         });
-
-        limiter.on('done', () => {
-            assert.strictEqual(_.size(results), 2);
-            assert.strictEqual(_.first(results), 'waiter');
-            assert.strictEqual(_.last(results), 'check please');
-            return done();
-        });
-
-        limiter.on('error', ({ error }) => {
-            assert(!error, `Got error ${error.message}`);
-            return done();
-        });
-
-        limiter.start();
     });
 
-    it('should be able to run in parallel with a limit of 3', done => {
-        const collection = ['waiter1', 'waiter2', 'check please'];
+    it('should do iterate 2 times and call done', async () => {
+        return new Promise((resolve, reject) => {
+            const collection = ['item1', 'item2'];
+            const limiter = new the.Limiter(collection);
 
-        const limiter = new the.Limiter(
-            collection,
-            async (value, key) => {
-                if (key === 0) {
-                    await the.wait(1000);
-                } else if (key === 1) {
-                    await the.wait(1000);
+            let iterations = 0;
+            limiter.on('iteration', () => {
+                iterations++;
+            });
+
+            limiter.on('done', () => {
+                try {
+                    assert.strictEqual(iterations, 2);
+                } catch (e) {
+                    return reject(e);
                 }
+                return resolve();
+            });
 
-                return value;
-            },
-            { limit: 3 }
-        );
+            limiter.on('error', ({ error }) => {
+                return reject(`Got error ${error.message}`);
+            });
 
-        let results = [];
-        limiter.on('iteration', ({ resultValue }) => {
-            results.push(resultValue);
+            limiter.start();
         });
+    });
 
-        let timer;
-        limiter.on('done', () => {
-            const totalTime = Date.now() - timer;
-            assert.strictEqual(_.size(results), 3);
-            assert(
-                totalTime < 2000,
-                `Expected execution to take less than 2 seconds to prove parallelism got ${totalTime}`
+    it('should be able to run serially with a limit of 1', async () => {
+        return new Promise((resolve, reject) => {
+            const collection = ['waiter', 'check please'];
+            const limiter = new the.Limiter(
+                collection,
+                async (value, key) => {
+                    if (key === 0) {
+                        await the.wait(1000);
+                    }
+
+                    return value;
+                },
+                { limit: 1 }
             );
-            assert.strictEqual(_.first(results), 'check please');
-            return done();
-        });
 
-        limiter.on('error', ({ error }) => {
-            assert(!error, `Got error ${error.message}`);
-            return done();
-        });
+            let results = [];
+            limiter.on('iteration', ({ resultValue }) => {
+                results.push(resultValue);
+            });
 
-        timer = Date.now();
-        limiter.start();
-    });
-
-    it('should be able to run in parallel with a limit of 2', done => {
-        const collection = ['waiter1', 'waiter2', 'check please'];
-
-        const limiter = new the.Limiter(
-            collection,
-            async (value, key) => {
-                if (key === 0) {
-                    await the.wait(2000);
-                } else if (key === 1) {
-                    await the.wait(1000);
+            limiter.on('done', () => {
+                try {
+                    assert.strictEqual(_.size(results), 2);
+                    assert.strictEqual(_.first(results), 'waiter');
+                    assert.strictEqual(_.last(results), 'check please');
+                } catch (e) {
+                    return reject(e);
                 }
 
-                return value;
-            },
-            { limit: 2 }
-        );
+                return resolve();
+            });
 
-        let results = [];
-        limiter.on('iteration', ({ resultValue }) => {
-            results.push(resultValue);
+            limiter.on('error', ({ error }) => {
+                return reject(`Got error ${error.message}`);
+            });
+
+            limiter.start();
         });
+    });
 
-        let timer;
-        limiter.on('done', () => {
-            const totalTime = Date.now() - timer;
-            assert.strictEqual(_.size(results), 3);
-            assert(totalTime < 3000, 'Expected execution to take less than 3 seconds to prove parallelism');
-            assert.strictEqual(results[0], 'waiter2');
-            assert.strictEqual(results[1], 'check please');
-            assert.strictEqual(results[2], 'waiter1');
-            return done();
+    it('should be able to run in parallel with a limit of 3', async () => {
+        return new Promise((resolve, reject) => {
+            const collection = ['waiter1', 'waiter2', 'check please'];
+
+            const limiter = new the.Limiter(
+                collection,
+                async (value, key) => {
+                    if (key === 0) {
+                        await the.wait(1000);
+                    } else if (key === 1) {
+                        await the.wait(1000);
+                    }
+
+                    return value;
+                },
+                { limit: 3 }
+            );
+
+            let results = [];
+            limiter.on('iteration', ({ resultValue }) => {
+                results.push(resultValue);
+            });
+
+            let timer;
+            limiter.on('done', () => {
+                const totalTime = Date.now() - timer;
+                try {
+                    assert.strictEqual(_.size(results), 3);
+                    assert(
+                        totalTime < 2000,
+                        `Expected execution to take less than 2 seconds to prove parallelism got ${totalTime}`
+                    );
+                    assert.strictEqual(_.first(results), 'check please');
+                } catch (e) {
+                    return reject(e);
+                }
+                return resolve();
+            });
+
+            limiter.on('error', ({ error }) => {
+                return reject(`Got error ${error.message}`);
+            });
+
+            timer = Date.now();
+            limiter.start();
         });
+    });
 
-        limiter.on('error', ({ error }) => {
-            assert(!error, `Got error ${error.message}`);
-            return done();
+    it('should be able to run in parallel with a limit of 2', async () => {
+        return new Promise((resolve, reject) => {
+            const collection = ['waiter1', 'waiter2', 'check please'];
+
+            const limiter = new the.Limiter(
+                collection,
+                async (value, key) => {
+                    if (key === 0) {
+                        await the.wait(2000);
+                    } else if (key === 1) {
+                        await the.wait(1000);
+                    }
+
+                    return value;
+                },
+                { limit: 2 }
+            );
+
+            let results = [];
+            limiter.on('iteration', ({ resultValue }) => {
+                results.push(resultValue);
+            });
+
+            let timer;
+            limiter.on('done', () => {
+                const totalTime = Date.now() - timer;
+                try {
+                    assert.strictEqual(_.size(results), 3);
+                    assert(
+                        totalTime < 3000,
+                        'Expected execution to take less than 3 seconds to prove parallelism'
+                    );
+                    assert.strictEqual(results[0], 'waiter2');
+                    assert.strictEqual(results[1], 'check please');
+                    assert.strictEqual(results[2], 'waiter1');
+                } catch (e) {
+                    return reject(e);
+                }
+
+                return resolve();
+            });
+
+            limiter.on('error', ({ error }) => {
+                return reject(`got error ${error}`);
+            });
+
+            timer = Date.now();
+            limiter.start();
         });
-
-        timer = Date.now();
-        limiter.start();
     });
 
     it('should throw for invalid channel', () => {

--- a/test/all.js
+++ b/test/all.js
@@ -8,10 +8,11 @@ describe('all test', function() {
         const result = await the.all([
             new Promise(resolve => resolve('hello')),
             'world',
-            () => 'how are you?'
+            () => 'how are you?',
+            null
         ]);
 
-        assert.deepStrictEqual(result, ['hello', 'world', 'how are you?']);
+        assert.deepStrictEqual(result, ['hello', 'world', 'how are you?', null]);
     });
 
     it('should run in series if the limit is 1', async () => {

--- a/test/all.js
+++ b/test/all.js
@@ -1,0 +1,63 @@
+const assert = require('assert');
+const the = require('../index');
+
+describe('all test', function() {
+    this.timeout(30000);
+
+    it('should resolve all types', async () => {
+        const result = await the.all([
+            new Promise(resolve => resolve('hello')),
+            'world',
+            () => 'how are you?'
+        ]);
+
+        assert.deepStrictEqual(result, ['hello', 'world', 'how are you?']);
+    });
+
+    it('should run in series if the limit is 1', async () => {
+        const collection = [
+            async () => {
+                await the.wait(500);
+                return `hello`;
+            },
+            'item2',
+            'item3'
+        ];
+
+        const output = await the.all(collection, { limit: 1 });
+        assert.deepStrictEqual(output, ['hello', 'item2', 'item3']);
+    });
+
+    it('should run in parallel if the limit greater than 1', async () => {
+        const collection = [
+            async () => {
+                await the.wait(600);
+                return `world`;
+            },
+            async () => {
+                await the.wait(500);
+                return `hello`;
+            },
+            async () => {
+                await the.wait(700);
+                return `how are you?`;
+            }
+        ];
+
+        const start = Date.now();
+        const output = await the.all(collection, { limit: 3 });
+        const duration = Date.now() - start;
+        assert(duration < 800, 'Expected promises to run in parallel');
+        assert.deepStrictEqual(output, ['world', 'hello', 'how are you?']);
+    });
+
+    it('should support objects', async () => {
+        const result = await the.all({
+            item1: new Promise(resolve => resolve('hello')),
+            item2: 'world',
+            item3: () => 'how are you?'
+        });
+
+        assert.deepStrictEqual(result, ['hello', 'world', 'how are you?']);
+    });
+});

--- a/test/any.js
+++ b/test/any.js
@@ -20,7 +20,7 @@ describe('all test', function() {
 
     it('should throw an error if no promises resolve', async () => {
         const collection = ['item1', 'item2', 'item3'];
-        const task = async (value, index) => {
+        const task = async () => {
             throw new Error('test error');
         };
         let err;
@@ -31,5 +31,18 @@ describe('all test', function() {
         }
         assert(err);
         assert(err instanceof Error);
+    });
+
+    it('should not error if last item resolves (edge case)', async () => {
+        const collection = ['item1', 'item2', 'item3', 'item4'];
+        const task = async (value, index) => {
+            if (index === 3) {
+                return 'hi';
+            }
+            throw new Error('test error');
+        };
+
+        const result = await the.any(collection, task);
+        assert.strictEqual(result, true);
     });
 });

--- a/test/any.js
+++ b/test/any.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const the = require('../index');
+
+describe('all test', function() {
+    this.timeout(30000);
+
+    it('should return true for a promise that passes', async () => {
+        const collection = ['item1', 'item2', 'item3'];
+        const task = async (value, index) => {
+            if (index === 1) {
+                return await new Promise(resolve => resolve());
+            } else {
+                throw new Error('test error');
+            }
+        };
+
+        const result = await the.any(collection, task);
+        assert.strictEqual(result, true);
+    });
+
+    it('should throw an error if no promises resolve', async () => {
+        const collection = ['item1', 'item2', 'item3'];
+        const task = async (value, index) => {
+            throw new Error('test error');
+        };
+        let err;
+        try {
+            await the.any(collection, task);
+        } catch (e) {
+            err = e;
+        }
+        assert(err);
+        assert(err instanceof Error);
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- removed dependency on p-any and p-all
- remove `start` function in favor of `some` (alias to `any`)

## How Has This Been Tested
- added new tests for added functions at 100% coverage
- fixed bad reporting of limiter test
