### PR TITLE
add error filter to retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,12 +285,15 @@ Retry promise a given number of times at an interval.
 | options | <code>Object</code> | Optional overrides. |
 | options.maxTries | <code>Number</code> | Maximum number of times to retry to promise. |
 | options.interval | <code>Number</code> \| <code>function</code> | Time to wait in ms between promise executions. |
+| options.errorFilter | <code>Any</code> \| <code>function</code> \| <code>Promise</code> | if supplied only retry if Any === error.message or function returns true |
 
 **Example**  
 ```js
 const the = require('await-the');
 await the.retry(myPromise, { maxTries: 10, interval: 100 });
 await the.retry(myPromise, { maxTries: 10, interval: numTriesSoFar => (numTriesSoFar * 100) });
+await the.retry(myPromise, { maxTries: 10, interval: errorFilter: 'My Expected Error' });
+await the.retry(myPromise, { maxTries: 10, interval: errorFilter: err => err.message === 'My Expected Error' });
 ```
 <a name="module_wait"></a>
 

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -18,15 +18,18 @@ const DEFAULT_INTERVAL = 2000;
  * const the = require('await-the');
  * await the.retry(myPromise, { maxTries: 10, interval: 100 });
  * await the.retry(myPromise, { maxTries: 10, interval: numTriesSoFar => (numTriesSoFar * 100) });
+ * await the.retry(myPromise, { maxTries: 10, interval: errorFilter: 'My Expected Error' });
+ * await the.retry(myPromise, { maxTries: 10, interval: errorFilter: err => err.message === 'My Expected Error' });
  *
  * @param {Promise} promise The promise to be resolved (or rejected) on the retry cadence.
  * @param {Object} options Optional overrides.
  * @param {Number} options.maxTries Maximum number of times to retry to promise.
  * @param {Number|Function} options.interval Time to wait in ms between promise executions.
+ * @param {Any|Function|Promise} options.errorFilter - if supplied only retry if Any === error.message or function returns true
  * @returns {*} The last thrown error or the result.
  */
 module.exports = async (promise, options = {}) => {
-    const { maxTries = 30, interval = DEFAULT_INTERVAL } = options;
+    const { maxTries = 30, interval = DEFAULT_INTERVAL, errorFilter } = options;
 
     let result,
         tries = 0,
@@ -45,6 +48,21 @@ module.exports = async (promise, options = {}) => {
         intervalFn = () => DEFAULT_INTERVAL;
     }
 
+    // the default error filter will always return true
+    let errorFilterFunction = () => {
+        return true;
+    };
+
+    if (errorFilter) {
+        if (_.isFunction(errorFilter)) {
+            errorFilterFunction = errorFilter;
+        } else {
+            errorFilterFunction = err => {
+                return _.get(err, 'message') === errorFilter;
+            };
+        }
+    }
+
     while (tries < maxTries) {
         tries++;
 
@@ -54,6 +72,11 @@ module.exports = async (promise, options = {}) => {
             break;
         } catch (error) {
             lastError = error;
+            const errorFilterResult = await errorFilterFunction(error);
+            // if errorFilterResult is not true we stop retrying
+            if (errorFilterResult !== true) {
+                break;
+            }
             // No reason to wait after the final failure
             // since we're not going to try again...
             if (tries < maxTries) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "await-the",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "description": "A utility module which provides straight-forward, powerful functions for working with async/await in JavaScript.",
     "main": "index.js",
     "author": "Olono, Inc.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
added errorFilter option to retry similar to how the async library has theirs implemented: http://caolan.github.io/async/docs.html#retry

## How Has This Been Tested

Added some new tests yop
