### PR TITLE
add backwards compat support for concurrency to map

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -25,12 +25,21 @@ const Limiter = require('./Limiter');
  * @returns {Array} An array containing the results for each index
  */
 module.exports = async (collection = [], task = () => {}, options) => {
+    const clonedOptions = _.cloneDeep(options);
+
+    // backwards compat for moving from concurrency to limit
+    if (!_.isEmpty(clonedOptions)) {
+        if (!_.isNil(clonedOptions.concurrency)) {
+            clonedOptions.limit = clonedOptions.concurrency;
+        }
+    }
+
     return new Promise((resolve, reject) => {
         // initialize output array so setting results can be done
         // out of order
         const output = new Array(_.size(collection));
 
-        const limiter = new Limiter(collection, task, options);
+        const limiter = new Limiter(collection, task, clonedOptions);
 
         limiter.on('error', ({ error } = {}) => {
             return reject(error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "await-the",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "A utility module which provides straight-forward, powerful functions for working with async/await in JavaScript.",
     "main": "index.js",
     "author": "Olono, Inc.",

--- a/test/map.js
+++ b/test/map.js
@@ -20,6 +20,20 @@ describe('Map test', function() {
         assert.deepStrictEqual(output, ['item10', 'item21', 'item32']);
     });
 
+    it('should run in series if the concurrency is 1', async () => {
+        const collection = ['item1', 'item2', 'item3'];
+        const task = async (value, key) => {
+            await the.wait(500);
+            return `${value}${key}`;
+        };
+
+        const start = Date.now();
+        const output = await the.map(collection, task, { concurrency: 1 });
+        const duration = Date.now() - start;
+        assert(duration >= 1500, 'Expected promises to run in series');
+        assert.deepStrictEqual(output, ['item10', 'item21', 'item32']);
+    });
+
     it('should run in parallel if the limit greater than 1', async () => {
         const collection = ['item1', 'item2', 'item3'];
         const task = async (value, key) => {

--- a/test/mapValues.js
+++ b/test/mapValues.js
@@ -36,6 +36,34 @@ describe('Map Values test', function() {
         assert(!!err);
     });
 
+    it('should run in series if the limit is 1', async () => {
+        const collection = ['item1', 'item2', 'item3'];
+        const task = async (value, key) => {
+            await the.wait(500);
+            return `${value}${key}`;
+        };
+
+        const start = Date.now();
+        const output = await the.mapValues(collection, task, { limit: 1 });
+        const duration = Date.now() - start;
+        assert(duration >= 1500, 'Expected promises to run in series');
+        assert.deepStrictEqual(output, { 0: 'item10', 1: 'item21', 2: 'item32' });
+    });
+
+    it('should run in series if the concurrency is 1', async () => {
+        const collection = ['item1', 'item2', 'item3'];
+        const task = async (value, key) => {
+            await the.wait(500);
+            return `${value}${key}`;
+        };
+
+        const start = Date.now();
+        const output = await the.mapValues(collection, task, { concurrency: 1 });
+        const duration = Date.now() - start;
+        assert(duration >= 1500, 'Expected promises to run in series');
+        assert.deepStrictEqual(output, { 0: 'item10', 1: 'item21', 2: 'item32' });
+    });
+
     it('should run in parallel if the limit greater than 1', async () => {
         const collection = {
             'item1.dummy': 'item-1',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
concurrency backwards compat was added to mapValues when 'limit' was introduced but not carried over to map
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
added tests
<!--- THIS IS REQUIRED! -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
