### PR TITLE
Ensure that task in Limiter is a promise

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Run tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": ["--colors", "--exit"]
+        }
+    ]
+}

--- a/lib/Limiter.js
+++ b/lib/Limiter.js
@@ -59,7 +59,11 @@ module.exports = class Limiter {
         this.currentIndex = 0; // keeps track of the index next to be iterated on
 
         this.collection = _.toPairs(collection);
-        this.task = task;
+
+        // Async-ify the task, so that it always returns a promise.
+        this.task = async (currentValue, currentKey) => {
+            return await task(currentValue, currentKey);
+        };
     }
 
     static get AVAILABLE_CHANNELS() {
@@ -114,16 +118,9 @@ module.exports = class Limiter {
 
         // run in process next tick so iterate function can return ASAP
         process.nextTick(() => {
-            const promise = this.task(currentValue, currentKey);
-            // if the function is 'promise-y' wait for the result
-            // otherwise return the value
-            if (promise instanceof Promise) {
-                promise
-                    .then(res => this.emitIteration(currentKey, { resultValue: res, index }))
-                    .catch(e => this.emitIteration(currentKey, { error: e, index }));
-            } else {
-                this.emitIteration(currentKey, { resultValue: promise, index });
-            }
+            this.task(currentValue, currentKey)
+                .then(res => this.emitIteration(currentKey, { resultValue: res, index }))
+                .catch(e => this.emitIteration(currentKey, { error: e, index }));
         });
 
         return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "await-the",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "description": "A utility module which provides straight-forward, powerful functions for working with async/await in JavaScript.",
     "main": "index.js",
     "author": "Olono, Inc.",
@@ -36,6 +36,7 @@
         "p-whilst": "^1.0.0"
     },
     "devDependencies": {
+        "bluebird": "^3.5.3",
         "eslint": "^4.18.2",
         "eslint-config-prettier": "^2.9.0",
         "eslint-plugin-prettier": "^2.6.0",


### PR DESCRIPTION
## Description

This PR ensures that the task in Limiter is always a promise, so that we don't have to process results from asynchronous tasks differently than synchronous ones.  That solves the issue of certain promises returning `false` from `instanceof Promise`, causing them to be mistakenly returned as values instead of resolved

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

First, I added the test and verified that it failed.  Then, I made the change and verified that the test (and all other tests) passed.

<!--- THIS IS REQUIRED! -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
