### PR TITLE
Use setImmediate instead of process.nextTick in Limiter

### DIFF
--- a/lib/Limiter.js
+++ b/lib/Limiter.js
@@ -117,7 +117,7 @@ module.exports = class Limiter {
         currentKey = _.isNaN(_.parseInt(currentKey)) ? currentKey : _.parseInt(currentKey);
 
         // run in process next tick so iterate function can return ASAP
-        process.nextTick(() => {
+        setImmediate(() => {
             this.task(currentValue, currentKey)
                 .then(res => this.emitIteration(currentKey, { resultValue: res, index }))
                 .catch(e => this.emitIteration(currentKey, { error: e, index }));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "await-the",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "description": "A utility module which provides straight-forward, powerful functions for working with async/await in JavaScript.",
     "main": "index.js",
     "author": "Olono, Inc.",

--- a/test/Limiter.js
+++ b/test/Limiter.js
@@ -396,9 +396,6 @@ describe('Limiter test', function() {
             const collection = _.range(0, 10);
             const limiter = new the.Limiter(
                 collection,
-                // Note that this is NOT an async function.  If it was, it would be wrapped by Node
-                // and return a nice Promise.  Instead, it returns a gnarly Bluebird promise for
-                // which `instanceof Promise` would return `false`.
                 async value => {
                     let now = Date.now();
                     const start = now;

--- a/test/Limiter.js
+++ b/test/Limiter.js
@@ -3,6 +3,8 @@
 const the = require('../index');
 const _ = require('lodash');
 const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 const bluebird = require('bluebird');
 
 describe('Limiter test', function() {
@@ -384,6 +386,63 @@ describe('Limiter test', function() {
             limiter.on('error', ({ error }) => {
                 return reject(`Got error ${error.message}`);
             });
+
+            limiter.start();
+        });
+    });
+
+    it('should not block the event loop', async () => {
+        return new Promise((resolve, reject) => {
+            const collection = _.range(0, 10);
+            const limiter = new the.Limiter(
+                collection,
+                // Note that this is NOT an async function.  If it was, it would be wrapped by Node
+                // and return a nice Promise.  Instead, it returns a gnarly Bluebird promise for
+                // which `instanceof Promise` would return `false`.
+                async value => {
+                    let now = Date.now();
+                    const start = now;
+                    while (now - start < 100) {
+                        now = Date.now();
+                    }
+                    return value;
+                },
+                { limit: 1 }
+            );
+
+            let results = [];
+            limiter.on('iteration', ({ resultValue }) => {
+                results.push(resultValue);
+            });
+
+            limiter.on('done', () => {
+                try {
+                    // If the event loop is blocked, this will be 10 since the Limiter
+                    // will finish before any IO or timer callbacks fire.
+                    assert.strictEqual(_.size(results), 12);
+                } catch (e) {
+                    return reject(e);
+                }
+
+                return resolve();
+            });
+
+            limiter.on('error', ({ error }) => {
+                return reject(`Got error ${error.message}`);
+            });
+
+            // Some IO that should happen before the limiter is done.
+            fs.readFile(path.resolve(__dirname, __filename), err => {
+                if (err) {
+                    throw new Error('Error reading file: ', JSON.stringify(err));
+                }
+                results.push('io');
+            });
+
+            // A timer that should happen before the limiter is done.
+            setTimeout(() => {
+                results.push('timer');
+            }, 50);
 
             limiter.start();
         });

--- a/test/Limiter.js
+++ b/test/Limiter.js
@@ -420,6 +420,8 @@ describe('Limiter test', function() {
                     // If the event loop is blocked, this will be 10 since the Limiter
                     // will finish before any IO or timer callbacks fire.
                     assert.strictEqual(_.size(results), 12);
+                    // Validate that numeric items were still processed in order.
+                    assert.deepEqual(_.without(results, 'io', 'timer'), collection);
                 } catch (e) {
                     return reject(e);
                 }


### PR DESCRIPTION
## Description

@dan-greff recently merged https://github.com/olono/rest-server/pull/1521 to break up some blocking code on rest-server using `await the.each`.  While reviewing it I realized that since the Limiter class ensures asynchronicity using `process.nextTick()`, it would still block IO and timer callbacks from firing (since `nextTick()` pushes code to the end of the current stack, [_not_ to the next tick of the event loop](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#process-nexttick-vs-setimmediate)).  Replacing this call with `setImmediate()` has the desired effect.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Added a new test to Limiter and verified that it fails with `process.nextTick()` (Limiter finishes before any IO or timer callbacks are called) and passed with `setImmediate()`.  

<!--- THIS IS REQUIRED! -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
