### PR TITLE
ISSUE-5330: Fix coercing of keys in Limiter

### DIFF
--- a/lib/Limiter.js
+++ b/lib/Limiter.js
@@ -52,6 +52,9 @@ module.exports = class Limiter {
         this.limit = _.get(options, 'limit', Infinity);
         this.bailOnError = _.get(options, 'bailOnError', true);
 
+        // flag array type so that we coerce keys to ints later.
+        this.isArray = _.isArray(collection);
+
         // init defaults
         this.emitters = {}; // where registered emitters are set
         this.numberDone = 0; // keeps track of how many tasks have been completed
@@ -114,7 +117,8 @@ module.exports = class Limiter {
 
         // to pairs takes array keys and turns them into strings
         // i.e. index 1 becomes '1' so this just coerces is back to a number
-        currentKey = _.isNaN(_.parseInt(currentKey)) ? currentKey : _.parseInt(currentKey);
+        // if the original collection was an array.
+        currentKey = this.isArray ? _.toNumber(currentKey) : currentKey;
 
         // run in process next tick so iterate function can return ASAP
         setImmediate(() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "await-the",
-    "version": "3.1.3",
+    "version": "3.1.4",
     "description": "A utility module which provides straight-forward, powerful functions for working with async/await in JavaScript.",
     "main": "index.js",
     "author": "Olono, Inc.",


### PR DESCRIPTION
## Description

We were attempting to coerce all keys using `parseInt` and relying on it to return `NaN` if the key wasn't numeric, but when presented with a string that _starts_ with a number `parseInt` will just truncate the non-numeric part.  Since the goal is to maintain array order and maintain the original keys exactly when passing to the `task` in each iteration, this PR adds a flag to the Limiter instance indicating that the original collection was an array and uses that to determine whether to coerce the keys or not.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Original tests pass, and added a new test for this case.

<!--- THIS IS REQUIRED! -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
