### PR TITLE
ISSUE-6910: Add multiResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Will bail on first error</p>
 <dt><a href="#module_mapValues">mapValues</a> ⇒ <code>Object</code></dt>
 <dd><p>Given an object of key-value pairs, run the given asynchronous task in parallel for each pair.</p>
 </dd>
-<dt><a href="#module_result">result</a> ⇒ <code>Array</code></dt>
+<dt><a href="#module_multiResult">multiResult</a> ⇒ <code>Array</code></dt>
 <dd><p>Given a function that expects a callback as its last argument, await a promisified version of that function
 and return the arguments sent to the callback as an array.</p>
 </dd>
@@ -311,9 +311,9 @@ const result = await the.mapValues({key1: 'value1'}, async (value, key) => {
 });
 // result is now an object with {key1: <resolved promise> }
 ```
-<a name="module_result"></a>
+<a name="module_multiResult"></a>
 
-## result ⇒ <code>Array</code>
+## multiResult ⇒ <code>Array</code>
 Given a function that expects a callback as its last argument, await a promisified version of that function
 and return the arguments sent to the callback as an array.
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,19 @@ return the results of the original function execution.</p>
 <dt><a href="#module_each">each</a></dt>
 <dd><p>Given a collection, run the given asynchronous task in parallel for each value of the collection.</p>
 </dd>
+<dt><a href="#module_every">every</a> ⇒ <code>Boolean</code></dt>
+<dd><p>Given a collection and a task return true if all promises resolve.
+Will bail on first error</p>
+</dd>
 <dt><a href="#module_map">map</a> ⇒ <code>Array</code></dt>
 <dd><p>Given a collection run a map over it</p>
 </dd>
 <dt><a href="#module_mapValues">mapValues</a> ⇒ <code>Object</code></dt>
 <dd><p>Given an object of key-value pairs, run the given asynchronous task in parallel for each pair.</p>
+</dd>
+<dt><a href="#module_result">result</a> ⇒ <code>Array</code></dt>
+<dd><p>Given a function that expects a callback as its last argument, await a promisified version of that function
+and return the arguments sent to the callback as an array.</p>
 </dd>
 <dt><a href="#module_result">result</a> ⇒ <code>*</code></dt>
 <dd><p>Given a function that expects a callback as its last argument, await a promisified version of that function
@@ -234,6 +242,31 @@ await the.each([1,2,3], someAsyncFunction, { limit: 2 });
 // will call `someAsyncFunction` on each value of the collection, with at most two functions
 // running in parallel at a time.
 ```
+<a name="module_every"></a>
+
+## every ⇒ <code>Boolean</code>
+Given a collection and a task return true if all promises resolve.
+Will bail on first error
+
+**Returns**: <code>Boolean</code> - true if all promises resolve, otherwise throws the error from the first rejected promise it encounters  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| collection | <code>Array</code> \| <code>Object</code> |  | Array or object of items to run the asynchronous task over. |
+| task | <code>function</code> |  | Promise to be awaited for each key, called with (value, key). |
+| options | <code>Object</code> |  | Optional overrides. |
+| options.limit | <code>Number</code> | <code>Infinity</code> | Number of concurrently pending promises returned by mapper. |
+
+**Example**  
+```js
+const the = require('await-the')
+const collection = ['item1', 'item2', 'item3'];
+const task = async (value, index) => {
+    return await new Promise(resolve => resolve());
+};
+const result = await the.every(collection, task);
+// result is true
+```
 <a name="module_map"></a>
 
 ## map ⇒ <code>Array</code>
@@ -277,6 +310,33 @@ const result = await the.mapValues({key1: 'value1'}, async (value, key) => {
     return somePromise(value);
 });
 // result is now an object with {key1: <resolved promise> }
+```
+<a name="module_result"></a>
+
+## result ⇒ <code>Array</code>
+Given a function that expects a callback as its last argument, await a promisified version of that function
+and return the arguments sent to the callback as an array.
+
+**Returns**: <code>Array</code> - The arguments sent to the callback, including the error.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fn | <code>function</code> \| <code>Array</code> | The async function to promisify and call, or an array of [class, method name]. |
+| ...args | <code>\*</code> | Variadic arguments to send to the function, _excluding_ the callback.  Note that _all_ parameters of the function besides the callback must have values supplied, even if they're optional. |
+
+**Example**  
+```js
+const the = require('await-the');
+const asyncSum = (x, y, callback) => callback(null, x + y, x * y);
+const [err, sum, product] = await the.multiResult(asyncSum, 1, 2);
+// will assign null to `err`, 3 to `sum` and 2 to `product`.
+
+await the.multiResult([someObj, 'someFnName'], 1, 2);
+// equivalent of `await the.multiResult(someObj.someFnName.bind(someObj), 1, 2)`
+
+const someFnWithOptionalArgs = (x, y = 1, opts = {}, callback) => callback(null, x + y);
+await the.multiResult(someFnWithOptionalArgs, 2, 1, {});
+// if the function has optional params before the callback, values must be supplied for all
 ```
 <a name="module_result"></a>
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const Limiter = require('./lib/Limiter');
 const map = require('./lib/map');
 const mapValues = require('./lib/mapValues');
 const result = require('./lib/result');
+const multiResult = require('./lib/multiResult');
 const retry = require('./lib/retry');
 const awaitWhile = require('./lib/while');
 const times = require('p-times');
@@ -36,6 +37,7 @@ module.exports = {
     map,
     mapValues,
     result,
+    multiResult,
     retry,
     some: any,
     times,

--- a/lib/multiResult.js
+++ b/lib/multiResult.js
@@ -12,7 +12,7 @@ const _ = require('lodash');
  * Given a function that expects a callback as its last argument, await a promisified version of that function
  * and return the arguments sent to the callback as an array.
  *
- * @module result
+ * @module multiResult
  * @example
  * const the = require('await-the');
  * const asyncSum = (x, y, callback) => callback(null, x + y, x * y);

--- a/lib/multiResult.js
+++ b/lib/multiResult.js
@@ -35,17 +35,17 @@ module.exports = async (fn, ...args) => {
         const [obj, objFnName] = fn;
         if (!_.isObject(obj)) {
             throw new Error(
-                `Expected first value of array argument to 'result()' to be an object; instead got: ${obj}`
+                `Expected first value of array argument to 'multiResult()' to be an object; instead got: ${obj}`
             );
         }
         if (!_.isFunction(obj[objFnName])) {
             throw new Error(
-                `Expected second value of array argument to 'result()' to be the name of a function on the object; instead got: ${obj[objFnName]} (function name: ${objFnName})`
+                `Expected second value of array argument to 'multiResult()' to be the name of a function on the object; instead got: ${obj[objFnName]} (function name: ${objFnName})`
             );
         }
         fn = obj[objFnName].bind(obj);
     } else if (!_.isFunction(fn)) {
-        throw new Error(`Expected argument to 'result()' to be a function or an array; instead got: ${fn}`);
+        throw new Error(`Expected argument to 'multiResult()' to be a function or an array; instead got: ${fn}`);
     }
     let resultsArray;
     try {

--- a/lib/multiResult.js
+++ b/lib/multiResult.js
@@ -1,0 +1,61 @@
+/**
+ * @file Given a function that expects a callback as its last argument, await a promisified version of that function
+ *       and return the arguments sent to the callback as an array.
+ * @copyright Copyright (c) 2018 Olono, Inc.
+ */
+
+'use strict';
+
+const _ = require('lodash');
+
+/**
+ * Given a function that expects a callback as its last argument, await a promisified version of that function
+ * and return the arguments sent to the callback as an array.
+ *
+ * @module result
+ * @example
+ * const the = require('await-the');
+ * const asyncSum = (x, y, callback) => callback(null, x + y, x * y);
+ * const [err, sum, product] = await the.multiResult(asyncSum, 1, 2);
+ * // will assign null to `err`, 3 to `sum` and 2 to `product`.
+ *
+ * await the.multiResult([someObj, 'someFnName'], 1, 2);
+ * // equivalent of `await the.multiResult(someObj.someFnName.bind(someObj), 1, 2)`
+ *
+ * const someFnWithOptionalArgs = (x, y = 1, opts = {}, callback) => callback(null, x + y);
+ * await the.multiResult(someFnWithOptionalArgs, 2, 1, {});
+ * // if the function has optional params before the callback, values must be supplied for all
+ *
+ * @param {Function|Array} fn The async function to promisify and call, or an array of [class, method name].
+ * @param {...*} args Variadic arguments to send to the function, _excluding_ the callback.  Note that _all_ parameters of the function besides the callback must have values supplied, even if they're optional.
+ * @returns {Array} The arguments sent to the callback, including the error.
+ */
+module.exports = async (fn, ...args) => {
+    if (_.isArray(fn)) {
+        const [obj, objFnName] = fn;
+        if (!_.isObject(obj)) {
+            throw new Error(
+                `Expected first value of array argument to 'result()' to be an object; instead got: ${obj}`
+            );
+        }
+        if (!_.isFunction(obj[objFnName])) {
+            throw new Error(
+                `Expected second value of array argument to 'result()' to be the name of a function on the object; instead got: ${obj[objFnName]} (function name: ${objFnName})`
+            );
+        }
+        fn = obj[objFnName].bind(obj);
+    } else if (!_.isFunction(fn)) {
+        throw new Error(`Expected argument to 'result()' to be a function or an array; instead got: ${fn}`);
+    }
+    let resultsArray;
+    try {
+        resultsArray = await new Promise(resolve => {
+            fn(...args, function(...callbackArgs) {
+                return resolve(callbackArgs);
+            });
+        });
+    } catch (e) {
+        resultsArray = [e];
+    }
+    return resultsArray;
+};

--- a/lib/multiResult.js
+++ b/lib/multiResult.js
@@ -1,7 +1,7 @@
 /**
  * @file Given a function that expects a callback as its last argument, await a promisified version of that function
  *       and return the arguments sent to the callback as an array.
- * @copyright Copyright (c) 2018 Olono, Inc.
+ * @copyright Copyright (c) 2019 Olono, Inc.
  */
 
 'use strict';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "await-the",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "description": "A utility module which provides straight-forward, powerful functions for working with async/await in JavaScript.",
     "main": "index.js",
     "author": "Olono, Inc.",

--- a/test/multiResult.js
+++ b/test/multiResult.js
@@ -1,0 +1,121 @@
+const assert = require('assert');
+const the = require('../index');
+
+describe.only('multiResult test', function() {
+    this.timeout(30000);
+
+    it('should return the correct results with a standard (null, result) callback', async () => {
+        const DELAY = 100;
+        const VALUE = 200;
+        const fn = (delay, value, cb) => {
+            setTimeout(() => {
+                return cb(null, value * 2);
+            }, delay);
+        };
+        const curTime = Date.now();
+        const [err, result] = await the.multiResult(fn, DELAY, VALUE);
+        assert.equal(result, VALUE * 2);
+        assert.equal(err, null);
+        const duration = Date.now() - curTime;
+        assert(
+            duration >= DELAY,
+            new Error(`Task took shorter time than it should have: expected > ${DELAY}, got ${duration}`)
+        );
+    });
+
+    it('should return the correct results with a standard (error, result) callback', async () => {
+        const DELAY = 100;
+        const VALUE = 200;
+        const fn = (delay, value, cb) => {
+            setTimeout(() => {
+                return cb(new Error('foo'), value * 2);
+            }, delay);
+        };
+        const curTime = Date.now();
+        const [err, result] = await the.multiResult(fn, DELAY, VALUE);
+        assert.equal(result, VALUE * 2);
+        assert(err instanceof Error);
+        assert.equal(err.message, 'foo');
+        const duration = Date.now() - curTime;
+        assert(
+            duration >= DELAY,
+            new Error(`Task took shorter time than it should have: expected > ${DELAY}, got ${duration}`)
+        );
+    });
+
+    it('should return the correct results with a multi-value (null, result1, result2) callback', async () => {
+        const DELAY = 100;
+        const VALUE = 200;
+        const fn = (delay, value, cb) => {
+            setTimeout(() => {
+                return cb(null, value * 2, 'foo');
+            }, delay);
+        };
+        const curTime = Date.now();
+        const [err, result1, result2] = await the.multiResult(fn, DELAY, VALUE);
+        assert.equal(result1, VALUE * 2);
+        assert.equal(result2, 'foo');
+        assert.equal(err, null);
+        const duration = Date.now() - curTime;
+        assert(
+            duration >= DELAY,
+            new Error(`Task took shorter time than it should have: expected > ${DELAY}, got ${duration}`)
+        );
+    });
+
+    it('should respect binding', async () => {
+        class Foo {
+            constructor(name) {
+                this.name = name;
+            }
+            fn(cb) {
+                setTimeout(() => {
+                    return cb(null, this.name);
+                }, 100);
+            }
+        }
+        const obj = new Foo('result-test');
+        const [err1, result1] = await the.multiResult(obj.fn.bind(obj));
+        assert.equal(err1, null);
+        assert.equal(result1, 'result-test');
+        const [err2, result2] = await the.multiResult(obj.fn.bind({ name: 'bar' }));
+        assert.equal(err2, null);
+        assert.equal(result2, 'bar');
+    });
+
+    it('should work with alternate syntax', async () => {
+        class Foo {
+            constructor(name) {
+                this.name = name;
+            }
+            fn(suffix, cb) {
+                setTimeout(() => {
+                    return cb(null, `${this.name}-${suffix}`);
+                }, 100);
+            }
+        }
+        const obj = new Foo('result-test');
+        const [err, result] = await the.multiResult([obj, 'fn'], 'foo');
+        assert.equal(err, null);
+        assert.equal(result, 'result-test-foo');
+    });
+
+    it('should capture error being thrown in the function', async () => {
+        const fn = (value /* cb */) => {
+            if (value === 5) {
+                throw new Error('it works!');
+            }
+        };
+        let error;
+        let result;
+        try {
+            [result] = await the.multiResult(fn, 5);
+        } catch (e) {
+            error = e;
+        } finally {
+            assert(!error);
+            assert(result instanceof Error);
+            assert.equal(result.message, 'it works!');
+        }
+    });
+});

--- a/test/multiResult.js
+++ b/test/multiResult.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const the = require('../index');
 
-describe.only('multiResult test', function() {
+describe('multiResult test', function() {
     this.timeout(30000);
 
     it('should return the correct results with a standard (null, result) callback', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We've run into an issue a few times in which `await the.result(someMethod)` can't be used because the callback used in someMethod expects multiple result arguments, or the calling code expects to be able to examine both the error argument and the result argument (that's not a great pattern, but it exists).  I'm adding a multiResult function that can be called like:

```
const [err, result1, result2] = await the.multiResult(someMethod);
```

so that if someMethod ultimate calls its callback like return `cb(new Error('foo'), 1, 2)` then the error, `1` and `2` will be assigned to `err`, `result1` and `result2` respectively.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Added new unit tests.
<!--- THIS IS REQUIRED! -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
