### PR TITLE
ISSUE-7211: Retain key order in _.mapValues

### DIFF
--- a/lib/mapValues.js
+++ b/lib/mapValues.js
@@ -47,7 +47,10 @@ module.exports = async (collection = {}, task = () => {}, options) => {
             _.set(output, [key], resultValue);
         });
         limiter.on('done', () => {
-            return resolve(output);
+            // Due to the wonders of parallelism, the output object could have
+            // a different key order than the original object.
+            // Use Lodash _.mapValues to map the new values to the old key order.
+            return resolve(_.mapValues(collection, (val, key) => output[key]));
         });
 
         limiter.start();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "await-the",
-    "version": "4.1.0",
+    "version": "4.2.0",
     "description": "A utility module which provides straight-forward, powerful functions for working with async/await in JavaScript.",
     "main": "index.js",
     "author": "Olono, Inc.",

--- a/test/mapValues.js
+++ b/test/mapValues.js
@@ -64,47 +64,59 @@ describe('Map Values test', function() {
         assert.deepStrictEqual(output, { 0: 'item10', 1: 'item21', 2: 'item32' });
     });
 
-    it('should run in parallel if the limit greater than 1', async () => {
+    it('should run in parallel if the limit greater than 1, and retain key order', async () => {
         const collection = {
             'item1.dummy': 'item-1',
             item2: 'item-2',
             item3: 'item-3'
         };
         const task = async (value, key) => {
-            await the.wait(500);
+            const delay = value === 'item-1' ? 500 : value === 'item-2' ? 300 : 150;
+            await the.wait(delay);
             return `${value}${key}`;
         };
 
         const start = Date.now();
-        const output = await the.mapValues(collection, task, { limit: 2 });
+        const output = await the.mapValues(collection, task, { limit: 3 });
         const duration = Date.now() - start;
-        assert(duration < 1500, 'Expected promises to run in parallel');
+        assert(duration < 550, 'Expected promises to run in parallel');
         assert.deepStrictEqual(output, {
             'item1.dummy': 'item-1item1.dummy',
             item2: 'item-2item2',
             item3: 'item-3item3'
         });
+        assert.deepEqual(
+            Object.keys(output),
+            ['item1.dummy', 'item2', 'item3'],
+            'Expected key order to be maintained'
+        );
     });
 
-    it('should run in parallel if the concurrency greater than 1', async () => {
+    it('should run in parallel if the concurrency greater than 1, and retain key order', async () => {
         const collection = {
             item1: 'item-1',
             item2: 'item-2',
             item3: 'item-3'
         };
         const task = async (value, key) => {
-            await the.wait(500);
+            const delay = value === 'item1' ? 500 : value === 'item2' ? 300 : 150;
+            await the.wait(delay);
             return `${value}${key}`;
         };
 
         const start = Date.now();
-        const output = await the.mapValues(collection, task, { concurrency: 2 });
+        const output = await the.mapValues(collection, task, { concurrency: 3 });
         const duration = Date.now() - start;
-        assert(duration < 1500, 'Expected promises to run in parallel');
+        assert(duration < 500, 'Expected promises to run in parallel');
         assert.deepStrictEqual(output, {
             item1: 'item-1item1',
             item2: 'item-2item2',
             item3: 'item-3item3'
         });
+        assert.deepEqual(
+            Object.keys(output),
+            ['item1', 'item2', 'item3'],
+            'Expected key order to be maintained'
+        );
     });
 });


### PR DESCRIPTION
## Description

This PR brings `mapValues` into parity with Lodash's `_.mapValues` by retaining key order even when running in parallel.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Updated existing tests to check for retained key order (and verified those tests fail without this code change).

<!--- THIS IS REQUIRED! -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
