### PR TITLE
ISSUE-7872 adjust npm publish to be public

### DIFF
--- a/.semaphore/production.yml
+++ b/.semaphore/production.yml
@@ -15,7 +15,7 @@ blocks:
       jobs:
         - name: Deploy
           commands:
-            - npm publish --access restricted
+            - npm publish --access public
       epilogue:
         on_pass:
           commands:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`await-the` npm package needs to be public. Adjust the npm publish the package to update it to public

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- THIS IS REQUIRED! -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
