### PR TITLE
ISSUE-12187 Limiter should use Node-standard EventEmitter API

### DIFF
--- a/lib/Limiter.js
+++ b/lib/Limiter.js
@@ -1,8 +1,7 @@
 /**
- * @file Given a collection and a task return resolved values of the task being ran per value via the emitters
+ * @file Given a collection and a task return resolved values of the task being ran per value via emitted events.
  * @copyright Copyright (c) 2018 Olono, Inc.
  */
-
 'use strict';
 
 const EventEmitter = require('events');
@@ -11,7 +10,7 @@ const _ = require('lodash');
 const DEFAULT_TASK = value => value;
 
 /**
- * Given a collection and a task return resolved values of the task being ran per value via the emitters
+ * Given a collection and a task, return resolved values of the task being ran per value via emitted events.
  *
  * @module Limiter
  * @example
@@ -60,7 +59,6 @@ module.exports = class Limiter extends EventEmitter {
         this.isArray = _.isArray(collection);
 
         // init defaults
-        this.emitters = {}; // where registered emitters are set
         this.numberDone = 0; // keeps track of how many tasks have been completed
         this.concurrency = 0; // keeps track of number of tasks in flight
         this.currentIndex = 0; // keeps track of the index next to be iterated on

--- a/lib/Limiter.js
+++ b/lib/Limiter.js
@@ -4,6 +4,8 @@
  */
 
 'use strict';
+
+const EventEmitter = require('events');
 const _ = require('lodash');
 
 const DEFAULT_TASK = value => value;
@@ -46,8 +48,10 @@ const DEFAULT_TASK = value => value;
  * @param {Object} options Optional overrides.
  * @param {Number} options.limit Optional limit to # of tasks to run in parallel.
  */
-module.exports = class Limiter {
+module.exports = class Limiter extends EventEmitter {
     constructor(collection = [], task = DEFAULT_TASK, options = {}) {
+        super();
+
         // init options
         this.limit = _.get(options, 'limit', Infinity);
         this.bailOnError = _.get(options, 'bailOnError', true);
@@ -131,17 +135,6 @@ module.exports = class Limiter {
     }
 
     /**
-     * emit - emit data on a given channel
-     * @private
-     * @param {String} channel - channel to emit data to
-     * @param {Object} data - data to emit
-     */
-    emit(channel, data) {
-        const emitter = _.get(this.emitters, channel, () => {});
-        emitter(data);
-    }
-
-    /**
      * emitIteration - when an iteration of running a task is complete emit and error or
      * an iteration event
      * - resultValue - value returned from the task
@@ -198,7 +191,6 @@ module.exports = class Limiter {
             throw new Error(`Channel: ${channel} is not valid`);
         }
 
-        // register emitter
-        _.set(this.emitters, channel, handler);
+        super.on(channel, handler);
     }
 };

--- a/lib/any.js
+++ b/lib/any.js
@@ -41,6 +41,10 @@ module.exports = async (collection, task) => {
             return resolve(true);
         });
 
+        limiter.on('error', () => {
+            // do nothing
+        });
+
         limiter.on('done', () => reject(new Error('No promises resolved')));
 
         limiter.start();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "await-the",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "description": "A utility module which provides straight-forward, powerful functions for working with async/await in JavaScript.",
     "main": "index.js",
     "author": "Olono, Inc.",

--- a/test/any.js
+++ b/test/any.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const the = require('../index');
 
-describe('all test', function() {
+describe('any test', function() {
     this.timeout(30000);
 
     it('should return true for a promise that passes', async () => {


### PR DESCRIPTION
## Description

We should strive to use Node-standard functionality where possible. The `EventEmitter` API is one such example -- it handles the listener registration API and the emit API for us.

## How Has This Been Tested

- Used `npm link` to bring this into `rest-server` and verify usage of limited iterators, such as those during Insights board generation, work as before.
